### PR TITLE
Patch release v1.2.3: reproducibility and skip_premap fixes

### DIFF
--- a/.github/workflows/riboseq-flow-ci.yml
+++ b/.github/workflows/riboseq-flow-ci.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
+      - name: Install Nextflow 25.10.0
+        env:
+          NXF_VER: "25.10.0"
+        run: |
           wget -qO- get.nextflow.io | bash
           mv nextflow /usr/local/bin/
+          nextflow -version
       - run: nextflow run ${GITHUB_WORKSPACE}/main.nf -profile github,docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [v1.2.3] - 2026-05-25
+### Changed
+- Pinned custom Docker container images to immutable SHA digests for reproducible execution.
+- Updated Singularity pre-download instructions to use digest-pinned container references.
+- Refined README wording for the "Why use riboseq-flow" section.
+
+### Fixed
+- Fixed `--skip_premap` runs so `--contaminants_fasta` is not required or checked when premapping is disabled.
+- Replaced non-idiomatic bitwise `&` with logical `&&` in the `RUST_QC` skip condition.
+
+---
 ## [v1.2.2] - 2026-03-28
 ### Added
 - Added .devcontainer for GitHub Codespaces support.
@@ -93,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - The first main release of **riboseq-flow**.
 
+[v1.2.3]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.3
 [v1.2.2]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.2
 [v1.2.1]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.1
 [v1.2.0]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - Fixed `--skip_premap` runs so `--contaminants_fasta` is not required or checked when premapping is disabled.
 - Replaced non-idiomatic bitwise `&` with logical `&&` in the `RUST_QC` skip condition.
+- Pinned the GitHub Actions CI Nextflow version to `25.10.0`.
 
 ---
 ## [v1.2.2] - 2026-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - The first main release of **riboseq-flow**.
 
-
+[v1.2.2]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.2
+[v1.2.1]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.1
 [v1.2.0]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.2.0
 [v1.1.1]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.1.1
 [v1.1.0]: https://github.com/iraiosub/riboseq-flow/releases/tag/v1.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ doi: "10.5281/zenodo.10372020"
 url: "https://github.com/iraiosub/riboseq-flow"
 repository-code: "https://github.com/iraiosub/riboseq-flow"
 
-version: "1.2.0"
-date-released: "2025-11-23"
+version: "1.2.3"
+date-released: "2026-05-25"
 license: "GPL-3.0"
 
 preferred-citation:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ riboseq-flow is a Nextflow DSL2 pipeline for the analysis and quality control of
 Nextflow installation instructions can be found [here](https://nf-co.re/docs/usage/installation).
 We recommend using Nextflow with `Java 17.0.9` or later.
 
-**Note:** The pipeline has been tested on with `Nextflow` versions `21.10.3`, `22.10.3`, `23.04.2`, `23.10.0`, `24.10.2` and `25.10.0`.
+**Note:** The pipeline has been tested on with `Nextflow` versions `21.10.3`, `22.10.3`, `23.04.2`, `23.10.0`, `24.10.2` and `25.10.0`. Nextflow versions newer than `25.10.0` are not yet officially supported.
 
 2. Pull the desired version of the pipeline from the GitHub repository:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We recommend using Nextflow with `Java 17.0.9` or later.
 2. Pull the desired version of the pipeline from the GitHub repository:
 
 ```
-nextflow pull iraiosub/riboseq-flow -r v1.2.2
+nextflow pull iraiosub/riboseq-flow -r v1.2.3
 ```
 
 3. Run the pipeline on the provided test dataset:
@@ -75,13 +75,13 @@ nextflow pull iraiosub/riboseq-flow -r v1.2.2
 Using Singularity:
 
 ```
-nextflow run iraiosub/riboseq-flow -r v1.2.2 -profile test,singularity
+nextflow run iraiosub/riboseq-flow -r v1.2.3 -profile test,singularity
 ```
 
 or using Docker:
 
 ```
-nextflow run iraiosub/riboseq-flow -r v1.2.2 -profile test,docker
+nextflow run iraiosub/riboseq-flow -r v1.2.3 -profile test,docker
 ```
 
 4. Check succesful execution.
@@ -93,7 +93,7 @@ nextflow run iraiosub/riboseq-flow -r v1.2.2 -profile test,docker
 2. Pull the desired version of the pipeline from the GitHub repository:
 
 ```
-nextflow pull iraiosub/riboseq-flow -r v1.2.2
+nextflow pull iraiosub/riboseq-flow -r v1.2.3
 ```
 
 3. Create a samplesheet `samplesheet.csv` with information about the samples you would like to analyse before running the pipeline. It has to be a comma-separated file with 2 columns, and a header row as shown in the example below.
@@ -110,7 +110,7 @@ sample3,/path/to/file3.fastq.gz
 4. Run the pipeline. The typical command for running the pipeline is as follows (the minimum parameters have been specified):
 
 ```
-nextflow run iraiosub/riboseq-flow -r v1.2.2 \
+nextflow run iraiosub/riboseq-flow -r v1.2.3 \
 -profile singularity,crick \
 -resume \
 --input samplesheet.csv \

--- a/README.md
+++ b/README.md
@@ -340,14 +340,14 @@ export NXF_SINGULARITY_CACHEDIR=/path/to/image/cache
 # change dir to your NXF_SINGULARITY_CACHEDIR path
 cd /path/to/image/cache
 
-singularity pull iraiosub-nf-riboseq-latest.img docker://iraiosub/nf-riboseq
-singularity pull iraiosub-mapping-length-latest.img docker://iraiosub/nf-riboseq-qc
-singularity pull iraiosub-nf-riboseq-dedup-latest.img docker://iraiosub/nf-riboseq-dedup
+singularity pull iraiosub-nf-riboseq-0c0c3386.img docker://iraiosub/nf-riboseq@sha256:0c0c33861d533653fb8fe6091f247e302d68c1e9b55ee5f5faf46979a9750a4b
+singularity pull iraiosub-nf-riboseq-qc-719e1879.img docker://iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba
+singularity pull iraiosub-nf-riboseq-dedup-45a6f6e9.img docker://iraiosub/nf-riboseq-dedup@sha256:45a6f6e9a16a4b082e5cb9f2ebad554c60d64f744831cc762444bfd233c82f0a
 ```
 
 ### Authors and contact
 
-riboseq-flow is written and maintained by Ira Iosub in Prof. Jernej Ule's lab at The Francis Crick Institute. It is based on a Snakemake pipeline in collaboration with its original author, Oscar Wilkins. 
+riboseq-flow is written and maintained by Ira Iosub in Prof. Jernej Ule's lab at The Francis Crick Institute. It is based on a Snakemake pipeline in collaboration with its original author, Oscar Wilkins.
 Contact email: `ira.iosub@crick.ac.uk`
 
 ### Citation policy
@@ -370,30 +370,18 @@ If you wish to make an addition or change to the pipeline, please follow these s
 2. Fork this repo.
 3. Create a new branch based on the `dev` branch, with a short, descriptive name e.g. `feat-colours` for making changes to a color palette.
 4. Modify the code exclusively on this new branch and mention the relavant issue in the commit messages.
-5. When your modifications are complete, submit a pull request to the `dev` branch describing the changes. 
+5. When your modifications are complete, submit a pull request to the `dev` branch describing the changes.
 6. Request a review from iraiosub on your pull request.
 7. The pull request will trigger a workflow execution on GitHub Actions for continuous integration (CI) of the pipeline.
-This is designed to automatically test riboseq-flow whenever a pull request is made to the main or dev branches of the repository.
-It ensures that the pipeline runs correctly in an Ubuntu environment, helping to catch any issues or errors early in the development process. 
+This is designed to automatically test riboseq-flow whenever a pull request is made to the `main` or `dev` branches of the repository.
+It ensures that the pipeline runs correctly in an Ubuntu environment, helping to catch any issues or errors early in the development process.
 
 ## Why use riboseq-flow
 
-- **User-friendly:** requires only minimal command-line experience.  
-- **Portable and reproducible:** runs identically across systems using Docker or Singularity.  
-- **Self-contained:** no manual dependency installation—each process runs in a container with the exact software it needs.  
-- **Reproducible results:** produces the same outputs regardless of platform, a cornerstone of computational reproducibility.  
-- **Scalable:** efficiently processes many samples in parallel for comparative studies.  
-- **Integrated QC:** combines data processing with extensive ribo-seq–specific QC.  
-- **Transparent:** tracks read counts at every step and provides custom QC reports for each sample.  
-- **Insightful:** visualises read fate and key metrics, helping users make informed downstream decisions.  
-- **Open and FAIR:** fully version-controlled, openly available, and compliant with FAIR principles.
-
-
-
-
-
-
-
-
-
-
+- **End-to-end ribo-seq analysis:** runs preprocessing, contaminant filtering, genome alignment, gene-level counting, P-site assignment, coverage track generation and ribo-seq-specific QC in a single workflow.
+- **Reproducible execution:** uses pinned software containers and version-controlled configuration to make analyses easier to rerun, review and share.
+- **Portable by design:** runs with Docker or Singularity across local workstations, servers and cluster environments.
+- **Scales to multi-sample studies:** uses Nextflow to parallelise independent samples and resume completed work when runs are interrupted.
+- **QC built into the workflow:** reports read fate, length distributions, frame periodicity, regional enrichment and other checks needed to assess ribo-seq data quality.
+- **Transparent outputs:** keeps intermediate logs, summary tables and MultiQC-compatible reports so downstream analyses can be traced back to each processing step.
+- **Open and citable:** maintained as an open, versioned workflow with a published citation for scientific reuse.

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -18,7 +18,7 @@ params {
     save_index = false
 
     // UMI options - UMI-tools
-    with_umi = false // for ts NNNNN
+    with_umi = false
     skip_umi_extract = false
     umi_extract_method = 'string'
     umi_pattern = ''
@@ -36,12 +36,6 @@ params {
     minimum_length = 20
     times_trimmed = 1
     cut_end = 0
-    // cutadapt_args = ''
-
-    // // Cutadapt_ts
-    // ts_trimming = false
-    // ts_adapter_threeprime = 'A{11}'
-    // trim_polyG = 3
 
     // Premapping - bowtie2
     skip_premap = false
@@ -65,7 +59,6 @@ params {
     after_premap_length_analysis = 'after_premap'
 
     // MultiQC
-    // multiqc_config = null
     multiqc_config = "$projectDir/assets/multiqc_config.yaml"
 
     // Gene-level counting - featureCounts
@@ -78,7 +71,6 @@ params {
 
     // P-site identification
     skip_psite = false
-    // length_range = '26:32' is now expected_length (see above)
     periodicity_threshold = 50
     psite_method = 'ribowaltz'
     exclude_start = 42

--- a/main.nf
+++ b/main.nf
@@ -47,7 +47,7 @@ if(params.org) {
 
 
 ch_genome_fasta = file(params.fasta, checkIfExists: true)
-ch_contaminants_fasta = file(params.contaminants_fasta, checkIfExists: true)
+ch_contaminants_fasta = params.skip_premap ? Channel.empty() : file(params.contaminants_fasta, checkIfExists: true)
 ch_genome_gtf = file(params.gtf, checkIfExists: true)
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -293,7 +293,7 @@ workflow RIBOSEQ {
             .map { [ it[1] ] }
             .collect() 
 
-        ch_merge_lemgth_filter = TRACK_READS.out.length_filter
+        ch_merge_legth_filter = TRACK_READS.out.length_filter
             .map { [ it[1] ] }
             .collect() 
 
@@ -305,7 +305,7 @@ workflow RIBOSEQ {
             ch_merge_start_dist,
             ch_merge_mapping_counts,
             ch_merge_frame,
-            ch_merge_lemgth_filter
+            ch_merge_legth_filter
         )
 
     }
@@ -375,7 +375,7 @@ workflow RIBOSEQ {
 
     }
 
-    if (!params.skip_psite & !params.skip_qc) {
+    if (!params.skip_psite && !params.skip_qc) {
 
         RUST_QC(
             PREPARE_RIBOSEQ_REFERENCE.out.transcript_info_fa,

--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,6 @@ if (!params.input) {
             .fromPath( params.input )
             .splitCsv(header:true)
             .map { row -> [ row.sample, file(row.fastq, checkIfExists: true) ] }
-            // .view()
 }
 
 
@@ -53,7 +52,6 @@ ch_genome_gtf = file(params.gtf, checkIfExists: true)
 /*
 MultiQC config
 */
-// ch_multiqc_config = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
 ch_multiqc_config = Channel.fromPath(params.multiqc_config, checkIfExists: true)
 
 /*
@@ -107,12 +105,6 @@ workflow RIBOSEQ {
         ch_genome_gtf,
         ch_contaminants_fasta
     )
-
-    // Test to asses channel type
-    // def test = PREPARE_RIBOSEQ_REFERENCE.out.genome_gtf
-    //                 .map { it[1] }
-
-    // println "genome_gtf_main class: ${test.getClass()}"
 
     // Extract UMIs and/or trim adapters and filter on min length, then run FASTQC
     PREPROCESS_READS(ch_input)

--- a/modules/local/featurecounts.nf
+++ b/modules/local/featurecounts.nf
@@ -54,8 +54,7 @@ process MERGE_FEATURECOUNTS {
 
     label 'process_single'
 
-    // conda '/camp/lab/ulej/home/users/luscomben/users/iosubi/projects/riboseq_nf/riboseq/env.yml'
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/featurecounts", pattern: "*.featureCounts.tsv.gz", mode: 'copy', overwrite: true
 

--- a/modules/local/mapping_length.nf
+++ b/modules/local/mapping_length.nf
@@ -8,7 +8,7 @@ process MAPPING_LENGTH_ANALYSIS {
     tag "${sample_id}"
     label 'process_medium'
 
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/riboseq_qc/mapping_length_analysis", pattern: "*.csv", mode: 'copy', overwrite: true
     

--- a/modules/local/ribocutter.nf
+++ b/modules/local/ribocutter.nf
@@ -54,7 +54,7 @@ process GET_PROPORTION_TARGETED {
 
     label 'process_single'
 
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/ribocutter"
 

--- a/modules/local/riboseq_qc.nf
+++ b/modules/local/riboseq_qc.nf
@@ -8,8 +8,7 @@ process RIBOSEQ_QC {
     tag "${sample_id}"
     label 'process_medium'
 
-    // conda '/camp/lab/ulej/home/users/luscomben/users/iosubi/projects/riboseq_nf/riboseq/env.yml'
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/riboseq_qc", pattern: "*.qc_results.*", mode: 'copy', overwrite: true
 
@@ -62,7 +61,7 @@ process SUMMARISE_RIBOSEQ_QC {
     tag "${workflow.runName}"
     label 'process_low'
 
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/riboseq_qc", pattern: "*.pdf", mode: 'copy', overwrite: true
     publishDir "${params.outdir}/riboseq_qc/multiqc_tables", pattern: "*_mqc.tsv", mode: 'copy', overwrite: true
@@ -107,7 +106,7 @@ process TRACK_READS {
     tag "${sample_id}"
     label 'process_low'
 
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/riboseq_qc/read_fate", mode: 'copy', overwrite: true
 
@@ -133,7 +132,7 @@ process PCA {
  
     label 'process_single'
 
-    container 'iraiosub/nf-riboseq:latest'
+    container 'iraiosub/nf-riboseq@sha256:0c0c33861d533653fb8fe6091f247e302d68c1e9b55ee5f5faf46979a9750a4b'
 
     publishDir "${params.outdir}/riboseq_qc/pca", pattern: '*.{gz,pdf}', mode: 'copy', overwrite: true
     publishDir "${params.outdir}/riboseq_qc/multiqc_tables", pattern: "*_mqc.tsv", mode: 'copy', overwrite: true

--- a/modules/local/ribowaltz.nf
+++ b/modules/local/ribowaltz.nf
@@ -54,10 +54,9 @@ process GET_PSITE_TRACKS {
 
     label 'process_high'
 
-    container 'iraiosub/nf-riboseq:latest'
+    container 'iraiosub/nf-riboseq@sha256:0c0c33861d533653fb8fe6091f247e302d68c1e9b55ee5f5faf46979a9750a4b'
 
     publishDir "${params.outdir}/coverage_tracks/psite", pattern: "*.psites.bed.gz", mode: 'copy', overwrite: true
-    // publishDir "${params.outdir}/coverage_tracks/psite", pattern: "*.bigWig", mode: 'copy', overwrite: true
 
     input:
     path(psite_table)
@@ -82,7 +81,7 @@ process RUST_QC {
 
 label 'process_single'
 
-    container 'iraiosub/nf-riboseq-qc:latest'
+    container 'iraiosub/nf-riboseq-qc@sha256:719e18799ff01b3071cb2187fcae78efaafe53faa604ca4a0bf224663f0cefba'
 
     publishDir "${params.outdir}/riboseq_qc/rust_analysis/", pattern: "*.rust_analysis.pdf", mode: 'copy', overwrite: true
     

--- a/modules/local/transcript_info.nf
+++ b/modules/local/transcript_info.nf
@@ -8,7 +8,7 @@ process GET_TRANSCRIPT_INFO {
     tag "$gtf"
     label 'process_single'
 
-    container 'iraiosub/nf-riboseq:latest'
+    container 'iraiosub/nf-riboseq@sha256:0c0c33861d533653fb8fe6091f247e302d68c1e9b55ee5f5faf46979a9750a4b'
 
     publishDir "${params.outdir}/annotation", mode: 'copy', overwrite: true
 

--- a/modules/local/umitools.nf
+++ b/modules/local/umitools.nf
@@ -40,8 +40,7 @@ process UMITOOLS_DEDUPLICATE {
     tag "${sample_id}"
     label 'process_medium'
 
-    // conda 'bioconda::umi_tools=1.1.2 conda bioconda::samtools=1.16.1 bioconda::bedtools=2.30.0'
-    container 'iraiosub/nf-riboseq-dedup:latest'
+    container 'iraiosub/nf-riboseq-dedup@sha256:45a6f6e9a16a4b082e5cb9f2ebad554c60d64f744831cc762444bfd233c82f0a'
 
     publishDir "${params.outdir}/deduplicated", pattern: "*.dedup.sorted.bam", mode: 'copy', overwrite: true
     publishDir "${params.outdir}/deduplicated", pattern: "*.dedup.sorted.bam.bai", mode: 'copy', overwrite: true

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,7 +57,6 @@ includeConfig 'conf/base.config'
 // Create run profiles
 profiles {
   test { includeConfig 'conf/test.config' }
-  full_test { includeConfig 'conf/full_test.config' }
   github { includeConfig 'conf/github.config' }
   crick { includeConfig 'conf/crick.config' }
   conda { enabled = false } // change this path to conda dir on your system

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,11 @@
  */
 
 
+manifest {
+  version = '1.2.3'
+}
+
+
 // Main parameters
 params {
   // General

--- a/subworkflows/prepare_reference.nf
+++ b/subworkflows/prepare_reference.nf
@@ -51,11 +51,13 @@ workflow PREPARE_RIBOSEQ_REFERENCE {
     // println "ch_genome_gtf class: ${ch_genome_gtf.getClass()}"
 
     ch_contaminants_fasta = Channel.empty()
-    if (!params.skip_premap && contaminants_fasta.toString().endsWith('.gz')) {
-        ch_contaminants_fasta = GUNZIP_CONTAMINANTS_FASTA ( [ [:], contaminants_fasta ] ).gunzip
-    } else {
-        // ch_contaminants_fasta = file(params.contaminants_fasta)
-        ch_contaminants_fasta = Channel.from( [ [ [:], contaminants_fasta ] ] )
+    if (!params.skip_premap) {
+        if (contaminants_fasta.toString().endsWith('.gz')) {
+            ch_contaminants_fasta = GUNZIP_CONTAMINANTS_FASTA ( [ [:], contaminants_fasta ] ).gunzip
+        } else {
+            // ch_contaminants_fasta = file(params.contaminants_fasta)
+            ch_contaminants_fasta = Channel.from( [ [ [:], contaminants_fasta ] ] )
+        }
     }
 
     // Prepare fasta index


### PR DESCRIPTION
Backward-compatible fixes/polish:
- `--skip_premap` no longer requiring `contaminants_fasta`: bug fix.
- `&` to `&&`: logic/idiom cleanup, no intended output change.
- pinning Docker images by digest: reproducibility fix, no intended workflow/API change.
- Pinned the GitHub Actions CI Nextflow version to `25.10.0`.
- `README` wording: documentation polish.